### PR TITLE
Fix favorites route comment

### DIFF
--- a/app/api/favorites/route.ts
+++ b/app/api/favorites/route.ts
@@ -1,4 +1,4 @@
-// app/api/hono/route.ts
+// app/api/favorites/route.ts
 import app from '@/server/hono'
 import { handle } from 'hono/vercel'
 


### PR DESCRIPTION
## Summary
- correct the header comment for the favorites API route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684437d4478083208ba33781a031e8e1