### PR TITLE
Improve dev speed with turbo bundler

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ pnpm dev
 bun dev
 ```
 
+This project uses the experimental Turbo bundler via the `npm run dev` script
+(`next dev --turbo`). When running in a dev container, this typically shortens
+the compilation time.
+
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,13 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  webpackDevMiddleware: (config) => {
+    config.watchOptions = {
+      ...(config.watchOptions ?? {}),
+      ignored: ["**/node_modules/**", "**/.git/**"],
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"
@@ -36,5 +36,8 @@
     "tsx": "^4.19.4",
     "tw-animate-css": "^1.3.4",
     "typescript": "^5"
+  },
+  "engines": {
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
## Summary
- default to `next dev --turbo` in `package.json`
- ignore unnecessary directories in dev watcher
- document turbo bundler use in README
- specify Node version requirement

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443f386e8c8320b28a72de02e69f80